### PR TITLE
FIX CE-555: Keep default nunjucks indent/newline behaviour

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,8 +5,6 @@ import * as core from '@actions/core'
 import * as path from 'path'
 import * as nunjucks from 'nunjucks'
 
-nunjucks.configure({ autoescape: true, trimBlocks: true, lstripBlocks: true })
-
 // From https://github.com/toniov/p-iteration/blob/master/lib/static-methods.js - MIT © Antonio V
 export async function forEach(array, callback) {
 	for (let index = 0; index < array.length; index++) {


### PR DESCRIPTION
These settings prevent us from controlling newline behaviour directly in templates, and also behave differently than equivalent `jinja2` configuration switches, preventing us from easily testing that our templates render properly.